### PR TITLE
Localization support and traditional Chinese translations

### DIFF
--- a/KeyStash.xcodeproj/project.pbxproj
+++ b/KeyStash.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		B0573CF62BB103CF00298E24 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		D30C58072AB91A5300A86426 /* resizeImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = resizeImage.swift; sourceTree = "<group>"; };
 		D3127DAD2B352803004343EF /* deleteAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = deleteAttachment.swift; sourceTree = "<group>"; };
 		D3163CE92ABBC91B00BC5F63 /* exportAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = exportAttachment.swift; sourceTree = "<group>"; };
@@ -195,6 +196,7 @@
 			isa = PBXGroup;
 			children = (
 				D39942C52AB509AE00B2DC39 /* Assets.xcassets */,
+				B0573CF62BB103CF00298E24 /* Localizable.xcstrings */,
 				D39942C02AB509AE00B2DC39 /* KeyStashApp.swift */,
 				D3C6503A2AB74CF300E75461 /* MenuBar.swift */,
 				D39697912ABCCB8C00A9F664 /* PrivacyInfo.xcprivacy */,
@@ -387,6 +389,7 @@
 			knownRegions = (
 				en,
 				Base,
+				"zh-Hant",
 			);
 			mainGroup = D39942A32AB5095A00B2DC39;
 			packageReferences = (

--- a/KeyStash.xcodeproj/project.pbxproj
+++ b/KeyStash.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B0573CF92BB106AD00298E24 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = B0573CF62BB103CF00298E24 /* Localizable.xcstrings */; };
 		D30C58082AB91A5300A86426 /* resizeImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30C58072AB91A5300A86426 /* resizeImage.swift */; };
 		D3127DAE2B352803004343EF /* deleteAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3127DAD2B352803004343EF /* deleteAttachment.swift */; };
 		D3163CEA2ABBC91B00BC5F63 /* exportAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3163CE92ABBC91B00BC5F63 /* exportAttachment.swift */; };
@@ -413,6 +414,7 @@
 			files = (
 				D39942D72AB509AF00B2DC39 /* Assets.xcassets in Resources */,
 				D39942B92AB5095B00B2DC39 /* Preview Assets.xcassets in Resources */,
+				B0573CF92BB106AD00298E24 /* Localizable.xcstrings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Valet/Localizable.xcstrings
+++ b/Valet/Localizable.xcstrings
@@ -1,0 +1,7 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+
+  },
+  "version" : "1.0"
+}

--- a/Valet/Localizable.xcstrings
+++ b/Valet/Localizable.xcstrings
@@ -1,7 +1,412 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "" : {
 
+    },
+    "🤔" : {
+
+    },
+    "Add" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增"
+          }
+        }
+      }
+    },
+    "Add App" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增程式"
+          }
+        }
+      }
+    },
+    "Add Attachment" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增附件"
+          }
+        }
+      }
+    },
+    "Add Item" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增物件"
+          }
+        }
+      }
+    },
+    "Add Manually" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "手動新增"
+          }
+        }
+      }
+    },
+    "All Apps" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有程式"
+          }
+        }
+      }
+    },
+    "App Name: " : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "程式名稱："
+          }
+        }
+      }
+    },
+    "Are you sure you want to empty the trash? Any files you have attached will also be deleted." : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您確定要清空垃圾桶？所有附件也將一起刪除。"
+          }
+        }
+      }
+    },
+    "Are you sure you want to remove this attachment? The file will be moved to your computer's Trash." : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您確定要刪除此附件？此檔案也將從您電腦裡的垃圾桶清空。"
+          }
+        }
+      }
+    },
+    "Cancel" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消"
+          }
+        }
+      }
+    },
+    "Choose Installed" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本機已安裝"
+          }
+        }
+      }
+    },
+    "Copy" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拷貝"
+          }
+        }
+      }
+    },
+    "Default Info" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預設資料"
+          }
+        }
+      }
+    },
+    "Delete" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除"
+          }
+        }
+      }
+    },
+    "Download" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下載"
+          }
+        }
+      }
+    },
+    "Edit" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯"
+          }
+        }
+      }
+    },
+    "Email" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "電郵"
+          }
+        }
+      }
+    },
+    "Empty Trash" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清空垃圾桶"
+          }
+        }
+      }
+    },
+    "Expiration Date" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "期限"
+          }
+        }
+      }
+    },
+    "Expired" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "過期"
+          }
+        }
+      }
+    },
+    "Export" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "輸出"
+          }
+        }
+      }
+    },
+    "General" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一般"
+          }
+        }
+      }
+    },
+    "iCloud" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iCloud"
+          }
+        }
+      }
+    },
+    "License Expires" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "授權過期"
+          }
+        }
+      }
+    },
+    "License Key" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "授權密鑰"
+          }
+        }
+      }
+    },
+    "Move to Trash" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除到垃圾桶"
+          }
+        }
+      }
+    },
+    "Name" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "姓名"
+          }
+        }
+      }
+    },
+    "Notes" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "備註"
+          }
+        }
+      }
+    },
+    "Registered To" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登記人"
+          }
+        }
+      }
+    },
+    "Restore" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "回復"
+          }
+        }
+      }
+    },
+    "Save" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存"
+          }
+        }
+      }
+    },
+    "Select an item" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇物件"
+          }
+        }
+      }
+    },
+    "Select App: " : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇程式："
+          }
+        }
+      }
+    },
+    "Select Icon..." : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇圖示⋯"
+          }
+        }
+      }
+    },
+    "Sort By" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "排序"
+          }
+        }
+      }
+    },
+    "Sort Order" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "次序"
+          }
+        }
+      }
+    },
+    "These will be applied to the 'Registered To' fields for any new licenses you add." : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "這些在您新增授權時會在「登記人」欄位運用。"
+          }
+        }
+      }
+    },
+    "Trash" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "垃圾桶"
+          }
+        }
+      }
+    },
+    "URL" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "網址"
+          }
+        }
+      }
+    },
+    "Website" : {
+      "localizations" : {
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "網站"
+          }
+        }
+      }
+    }
   },
   "version" : "1.0"
 }

--- a/Valet/Localizable.xcstrings
+++ b/Valet/Localizable.xcstrings
@@ -287,6 +287,38 @@
         }
       }
     },
+    "OrderOptions.asc" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ascending"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "遞增順序"
+          }
+        }
+      }
+    },
+    "OrderOptions.desc" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descending"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "遞減順序"
+          }
+        }
+      }
+    },
     "Registered To" : {
       "localizations" : {
         "zh-Hant" : {
@@ -363,6 +395,54 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "次序"
+          }
+        }
+      }
+    },
+    "SortOptions.byAddedDt" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Date Added"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加入日期"
+          }
+        }
+      }
+    },
+    "SortOptions.byName" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Name"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名稱"
+          }
+        }
+      }
+    },
+    "SortOptions.byUpdatedDt" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Date Updated"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新日期"
           }
         }
       }

--- a/Valet/Logic/Utils/sortBy.swift
+++ b/Valet/Logic/Utils/sortBy.swift
@@ -4,11 +4,26 @@ enum SortOptions: String, CaseIterable {
 	case byName = "Name"
 	case byAddedDt = "Date Added"
 	case byUpdatedDt = "Date Updated"
+	
+	func localizedString() -> String {
+		switch self {
+		case .byName: return String(localized: "SortOptions.byName")
+		case .byAddedDt: return String(localized: "SortOptions.byAddedDt")
+		case .byUpdatedDt: return String(localized: "SortOptions.byUpdatedDt")
+		}
+	}
 }
 
 enum OrderOptions: String, CaseIterable {
 	case asc = "Ascending"
 	case desc = "Descending"
+	
+	func localizedString() -> String {
+		switch self {
+		case .asc: return String(localized: "OrderOptions.asc")
+		case .desc: return String(localized: "OrderOptions.desc")
+		}
+	}
 }
 
 func sortBy(sort: SortOptions, order: OrderOptions) -> ((License, License) -> Bool) {

--- a/Valet/Views/AppKit/SearchBar.swift
+++ b/Valet/Views/AppKit/SearchBar.swift
@@ -16,12 +16,12 @@ struct SearchBar: View {
 				Menu(content: {
 					Picker("Sort By", selection: $selectedSort, content: {
 						ForEach(SortOptions.allCases, id: \.self) { sortOption in
-							Text(sortOption.rawValue).tag(sortOption)
+							Text(sortOption.localizedString()).tag(sortOption)
 						}
 					})
 					Picker("Sort Order", selection: $selectedSortOrder, content: {
 						ForEach(OrderOptions.allCases, id: \.self) { orderOption in
-							Text(orderOption.rawValue).tag(orderOption)
+							Text(orderOption.localizedString()).tag(orderOption)
 						}
 					})
 				}, label: {

--- a/Valet/Views/LicenseViews/LicenseListView.swift
+++ b/Valet/Views/LicenseViews/LicenseListView.swift
@@ -85,7 +85,7 @@ struct LicenseListView: View {
 			}
 		}
 		.onAppear(perform: databaseManager.fetchData)
-		.navigationTitle(snakeToTitleCase(appState.sidebarSelection))
+		.navigationTitle(LocalizedStringKey(snakeToTitleCase(appState.sidebarSelection)))
 		.confirmationDialog("Are you sure you want to empty the trash? Any files you have attached will also be deleted.", isPresented: $confirmDeleteAll, actions: {
 			Button("Empty Trash", role: .destructive, action: {
 				emptyTrash(databaseManager.dbQueue)


### PR DESCRIPTION
Note that a string like "Name" can translate differently because it can mean the name of an app or the name of the user, so I've had to create different identifiers like "SortOptions.byName" to distinguish the two.

Here's a screenshot of the app in Chinese:

<img width="902" alt="Screenshot 2024-03-24 at 6 54 43 PM" src="https://github.com/ghall89/KeyStash/assets/140762048/9732b2b1-c86f-408a-b069-b0f46913f16c">

Also, you can probably remove the rawValues and `String` compliance of `SortOptions` and `OrderOptions` because I don't think they're used anymore, now that the view calls the new `localizedString()` instead.